### PR TITLE
Fix the call to the old crypto API (OTP 22+ compat)

### DIFF
--- a/lib/slack_verify.ex
+++ b/lib/slack_verify.ex
@@ -61,8 +61,7 @@ defmodule SlackVerify do
   end
 
   defp sha256(key, string) do
-    :sha256
-    |> :crypto.hmac(key, string)
+    :crypto.mac(:hmac, :sha256, key, string)
     |> Base.encode16(case: :lower)
   end
 


### PR DESCRIPTION
In OTP 22, the crypto module switched to [a new API](https://beta.erlang.org/docs/22/apps/crypto/new_api.html), breaking this code in more recent versions of OTP. This commit fixes that bug.